### PR TITLE
refactor: Tooltip.jsのロジックをuseTooltipに移動し責務を分離

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -5,16 +5,13 @@ import useTooltip from "../hooks/useTooltip";
 const Tooltip = () => {
   const tooltipText = useTooltipStore((state) => state.tooltipText);
   const tooltipRef = useRef(null);
-  const { correctedPosition, tooltipOpacity, tooltipVisibility } = useTooltip(tooltipRef);
+  const { correctedPosition, isTooltipVisible } = useTooltip(tooltipRef);
 
   return (
     <span
       ref={tooltipRef}
-      className="tooltip"
+      className={`tooltip tooltip--${isTooltipVisible}`}
       style={{
-        // opacity: isOpenMenu ? 0 : tooltipOpacity,
-        opacity: tooltipOpacity,
-        visibility: tooltipVisibility,
         top: correctedPosition.y,
         left: correctedPosition.x,
       }}

--- a/src/hooks/useTooltip.js
+++ b/src/hooks/useTooltip.js
@@ -9,9 +9,7 @@ const useTooltip = (tooltipRef) => {
   const tooltipPosition = useTooltipStore((state) => state.tooltipPosition);
   const trackMousePosition = useTooltipStore((state) => state.trackMousePosition);
 
-  const isTooltipVisible = isHovered && !isButtonPressed;
-  const tooltipOpacity = isTooltipVisible ? 1 : 0;
-  const tooltipVisibility = isTooltipVisible ? "visible" : "hidden";
+  const isTooltipVisible = isHovered && !isButtonPressed ? "visible" : "hidden";
 
   const OFFSET_X = 12;
   const OFFSET_Y = 18;
@@ -38,7 +36,6 @@ const useTooltip = (tooltipRef) => {
   }, [tooltipPosition]);
 
   useEffect(() => {
-    console.log("✅✅✅✅✅✅");
     window.addEventListener("mousemove", trackMousePosition);
     return () => {
       window.removeEventListener("mousemove", trackMousePosition);
@@ -47,8 +44,7 @@ const useTooltip = (tooltipRef) => {
 
   return {
     correctedPosition,
-    tooltipOpacity,
-    tooltipVisibility,
+    isTooltipVisible,
   };
 };
 

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -708,8 +708,6 @@ footer {
 }
 
 .tooltip {
-  visibility: hidden;
-  opacity: 0;
   border: 1px solid #141414;
   padding: 6px 10px;
   line-height: 1;
@@ -725,6 +723,16 @@ footer {
     right 1s,
     opacity 0.2s ease-in;
   z-index: 3001;
+}
+
+.tooltip--hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.tooltip--visible {
+  visibility: visible;
+  opacity: 1;
 }
 
 .thumbnail-expanded {


### PR DESCRIPTION
## 背景
Tooltip.jsは表示以外の処理や状態管理（位置計算、表示/非表示制御、マウス追跡など）抱えており、
コンポーネントの責務が肥大化していた。

## 概要
UIの表示以外のロジックをカスタムフックに切り出して責務を分離。
さらにopacity / visibilityのuseStateを廃止してクラスを付与して表示 / 非表示を切り替えるように変更