### PR TITLE
refactor: TrackInfoのフェード処理を既存フックに置き換え、マジックナンバーを定数化

### DIFF
--- a/src/components/tracks/TrackInfo.js
+++ b/src/components/tracks/TrackInfo.js
@@ -7,8 +7,10 @@ import { isFallback } from "../../utils/isFallback";
 import useFadeTransition from "../../hooks/useFadeTransition";
 
 const TrackInfo = () => {
-  const imgRef = useRef(null);
-  const [width, setWidth] = useState(85);
+  const MIN_WIDTH = 150;
+  const DEFAULT_WIDTH = 85;
+
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
 
   const currentTitle = usePlaybackStore((state) => state.currentTitle);
   const currentArtistName = usePlaybackStore((state) => state.currentArtistName);
@@ -23,6 +25,7 @@ const TrackInfo = () => {
   const { handleTrackInfoClick, isVisible } = useContext(TrackInfoContext);
   useDelayedText(isVisible, "全画面表示：オフ", "全画面表示");
 
+  const imgRef = useRef(null);
   const transitionRef = useRef(null);
   const trackInfoRef = useRef(null);
   const trackMetaRef = useRef(null);
@@ -32,17 +35,18 @@ const TrackInfo = () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (!trackInfoRef.current || !trackMetaRef.current) return;
-      const offsetValue = 35;
+      const OFFSET_VALUE = 35;
+
       const coverArtWidth = imgRef.current.clientWidth;
       const trackMetaWidth = trackMetaRef.current.clientWidth;
       let newWidth;
       if (isVisible) {
-        newWidth = trackMetaWidth + offsetValue;
+        newWidth = trackMetaWidth + OFFSET_VALUE;
       } else {
-        newWidth = coverArtWidth + trackMetaWidth + offsetValue;
+        newWidth = coverArtWidth + trackMetaWidth + OFFSET_VALUE;
       }
-      if (newWidth < 150) {
-        setWidth(150);
+      if (newWidth < MIN_WIDTH) {
+        setWidth(MIN_WIDTH);
       } else {
         setWidth(newWidth);
       }


### PR DESCRIPTION
## 背景
TrackInfo コンポーネントには表示に関係ないロジック（フェードアニメーション、幅計算、遅延処理など）が混在しており、
コードの可読性や保守性が低下していた。

以前作成済みの useFadeTransition フックが存在したため、今回のリファクタリングでは既存のカスタムフックに置き換える形でフェードアニメーション処理を整理。

## 変更内容
- 既存のfadeTransitionをuseFadeTransitionフックに置き換え
- useLayoutEffectをuseEffectに置き換え
- 未使用のuseStateを削除
- 幅計算の副作用にクリーンアップを追加
- 幅計算などのマジックナンバーを定数化