### PR TITLE
fix: Spotify SDKの認証周りのバグ修正

### DIFF
--- a/src/utils/spotifyAuth.js
+++ b/src/utils/spotifyAuth.js
@@ -105,12 +105,11 @@ function loadSpotifySDK() {
 
 export async function initSpotifyPlayer(setPlayer, setDeviceId, setToken) {
   const DEFAULT_VOLUME = 0.3;
-  const TIMEOUT_MS = 3000;
   const currentToken = window.localStorage.getItem("access_token");
 
   await loadSpotifySDK();
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const playerInstance = new window.Spotify.Player({
       name: "MyMusicPlayer",
       getOAuthToken: async (cb) => {
@@ -129,12 +128,9 @@ export async function initSpotifyPlayer(setPlayer, setDeviceId, setToken) {
       volume: DEFAULT_VOLUME,
     });
 
-    const timer = setTimeout(() => reject(new Error("SPOTIFY_PLAYER_READY_TIMEOUT")), TIMEOUT_MS);
-
     playerInstance.addListener("ready", ({ device_id }) => {
-      clearTimeout(timer);
       setDeviceId(device_id);
-      resolve({ playerInstance, newDeviceId: device_id });
+      resolve({ playerInstance });
     });
 
     playerInstance.connect();


### PR DESCRIPTION
## 概要
ページをロードするたびに新しいトークンが発行されていた。また、デバイスID無効時の再取得でうまく動作せず再生に失敗していた。このバグを修正しようとしたが、デバイスIDの再取得は実用上のメリットが少なく、コードを複雑にしていたため削除し、代わりにユーザーへリロードを促す通知を表示するよう変更した。

## バグ修正
- ページロード時に不要なトークン更新が走らないよう修正
- デバイスID無効時の再取得処理を削除し、代わりにユーザーへリロードを促す通知を表示