### PR TITLE
fix: 新規プレイリスト作成時に常にバリデーションが表示されるバグを修正

### DIFF
--- a/src/components/playlists/CreatePlaylist.tsx
+++ b/src/components/playlists/CreatePlaylist.tsx
@@ -25,7 +25,6 @@ const CreatePlaylist = () => {
   const errorMessage = usePlaylistStore((state) => state.errorMessage);
   const isShaking = usePlaylistStore((state) => state.isShaking);
   const setIsShaking = usePlaylistStore((state) => state.setIsShaking);
-  const setPlaylistNameRef = usePlaylistStore((state) => state.setPlaylistNameRef);
   const hideCreatePlaylistModal = usePlaylistStore((state) => state.hideCreatePlaylistModal);
   const handleCreatePlaylist = usePlaylistStore((state) => state.handleCreatePlaylist);
   const selectedTrack = usePlaylistSelectionStore((state) => state.selectedTrack);
@@ -36,14 +35,9 @@ const CreatePlaylist = () => {
   const SHAKE_DURATION_MS = 600;
 
   useEffect(() => {
-    if (playlistNameRef.current) {
-      setPlaylistNameRef(playlistNameRef.current.value);
-    }
-  }, [playlistNameRef]);
-
-  useEffect(() => {
     if (isCreateVisible && playlistNameRef.current) {
       playlistNameRef.current.focus();
+      playlistNameRef.current.value = "";
     }
   }, [isCreateVisible]);
 
@@ -78,7 +72,7 @@ const CreatePlaylist = () => {
               className="playlist-page__create-playlist-modal-input modal-input"
               id="title"
               ref={playlistNameRef}
-              onKeyDown={(e) => e.key === "Enter" && handleCreatePlaylist()}
+              onKeyDown={(e) => e.key === "Enter" && handleCreatePlaylist(playlistNameRef.current?.value ?? "")}
             />
 
             {errorMessage && (
@@ -97,7 +91,7 @@ const CreatePlaylist = () => {
             </button>
             <button
               className="playlist-page__create-playlist-modal-create modal-cancel-submit-button modal-submit-button"
-              onClick={handleCreatePlaylist}
+              onClick={() => handleCreatePlaylist(playlistNameRef.current?.value ?? "")}
             >
               作成
             </button>

--- a/src/store/playlistStore.ts
+++ b/src/store/playlistStore.ts
@@ -27,7 +27,6 @@ type PlaylistStore = {
   isShaking: boolean;
   preselectedTrack: PlaylistObject | null;
   isCoverImageFading: boolean;
-  playlistNameRef: string | null;
 
   addSelectedTrackToPlaylistRef: () => void;
 
@@ -43,7 +42,6 @@ type PlaylistStore = {
   setIsShaking: (isShaking: boolean) => void;
   setPreselectedTrack: (preselectedTrack: PlaylistObject | null) => void;
   setIsCoverImageFading: (isCoverImageFading: boolean) => void;
-  setPlaylistNameRef: (playlistNameRef: string | null) => void;
 
   goToPage: (navigate: (path: string) => void, path: string) => void;
 
@@ -52,7 +50,7 @@ type PlaylistStore = {
   showDeletePlaylistModal: () => void;
   hideDeletePlaylistModal: () => void;
   triggerError: (message: string) => void;
-  handleCreatePlaylist: () => Promise<void> | Promise<string>;
+  handleCreatePlaylist: (name: string | null) => Promise<void> | Promise<string>;
   deletePlaylist: (playlistId: string, navigate: (url: string) => void) => Promise<void>;
   showCoverImages: () => void;
   fadeCoverImages: () => void;
@@ -74,7 +72,6 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
   preselectedTrack: null,
   isCoverImageFading: false,
 
-  playlistNameRef: "",
   addSelectedTrackToPlaylistRef: () => {},
 
   setPlaylistInfo: (playlistInfo) => set({ playlistInfo }),
@@ -98,12 +95,11 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
   setIsShaking: (isShaking) => set({ isShaking }),
   setPreselectedTrack: (preselectedTrack) => set({ preselectedTrack }),
   setIsCoverImageFading: (isCoverImageFading) => set({ isCoverImageFading }),
-  setPlaylistNameRef: (playlistNameRef) => set({ playlistNameRef }),
 
   goToPage: (navigate, path) => navigate(path),
 
   showCreatePlaylistModal: () => {
-    set({ isCreateVisible: true, errorMessage: "", playlistNameRef: "" });
+    set({ isCreateVisible: true, errorMessage: "" });
   },
 
   hideCreatePlaylistModal: () => {
@@ -122,12 +118,12 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
     set({ errorMessage: message, isShaking: true });
   },
 
-  handleCreatePlaylist: async () => {
-    const { playlistNameRef, setPlaylistNameRef, hideCreatePlaylistModal, triggerError } = get();
+  handleCreatePlaylist: async (name) => {
+    const { hideCreatePlaylistModal, triggerError } = get();
     const showMessage = useActionSuccessMessageStore.getState().showMessage;
-    const newName = playlistNameRef ?? "";
+    name = name ?? "";
 
-    const validationError = validatePlaylistName(newName);
+    const validationError = validatePlaylistName(name);
 
     if (validationError) {
       return triggerError(validationError);
@@ -139,9 +135,7 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          name: newName,
-        }),
+        body: JSON.stringify({ name }),
       });
 
       if (!response.ok) {
@@ -161,7 +155,6 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
       const data = await response.json();
       console.log(data);
       showMessage("newPlaylist");
-      setPlaylistNameRef("");
       set({ preselectedTrack: null });
       hideCreatePlaylistModal();
     } catch {


### PR DESCRIPTION
## 概要
関連Issue: #128 
新規プレイリスト作成時に、名前を入力しても「名前を入力してください」と常に表示されるバグを修正

## 変更内容
`playlistStore`でplaylistnameRefを使って入力した値を取得していたが、それを廃止して handleCreatePlaylist関数の引数に入力した値を入れるように変更した。

- `playlistStore`で`playlistNameRef`を用いて値を取得していたが処理を廃止
- `handleCreatePlaylist`関数の引数に入力値を直接渡す方法に変更
- `playlistNameRef`関連のコードを削除