### PR TITLE
fix: プレイリスト作成後に反映されないバグを修正

### DIFF
--- a/src/hooks/useFetchPlaylists.ts
+++ b/src/hooks/useFetchPlaylists.ts
@@ -6,6 +6,8 @@ const useFetchPlaylists = () => {
   const [isPlaylistsLoading, setIsPlaylistsLoading] = useState(true);
   const playlists = usePlaylistStore((state) => state.playlists);
   const setPlaylists = usePlaylistStore((state) => state.setPlaylists);
+  const refreshTrigger = usePlaylistStore((state) => state.refreshTrigger);
+  const setRefreshTrigger = usePlaylistStore((state) => state.setRefreshTrigger);
 
   const showMessage = useActionSuccessMessageStore((state) => state.showMessage);
 
@@ -22,7 +24,8 @@ const useFetchPlaylists = () => {
   useEffect(() => {
     setIsPlaylistsLoading(true);
     const cachedPlaylists = localStorage.getItem("playlists");
-    if (cachedPlaylists) {
+
+    if (cachedPlaylists && refreshTrigger === 0) {
       setPlaylists(JSON.parse(cachedPlaylists));
       setIsPlaylistsLoading(false);
       return;
@@ -40,11 +43,12 @@ const useFetchPlaylists = () => {
         const data = await response.json();
         setPlaylists(data);
         localStorage.setItem("playlists", JSON.stringify(data));
+        setRefreshTrigger(0);
       } catch (error) {
         fetchPlaylistsFailed(error);
       }
     })();
-  }, []);
+  }, [refreshTrigger]);
   return { playlists, isPlaylistsLoading };
 };
 

--- a/src/store/playlistStore.ts
+++ b/src/store/playlistStore.ts
@@ -27,6 +27,7 @@ type PlaylistStore = {
   isShaking: boolean;
   preselectedTrack: PlaylistObject | null;
   isCoverImageFading: boolean;
+  refreshTrigger: number;
 
   addSelectedTrackToPlaylistRef: () => void;
 
@@ -42,6 +43,7 @@ type PlaylistStore = {
   setIsShaking: (isShaking: boolean) => void;
   setPreselectedTrack: (preselectedTrack: PlaylistObject | null) => void;
   setIsCoverImageFading: (isCoverImageFading: boolean) => void;
+  setRefreshTrigger: (value: number | ((prev: number) => number)) => void;
 
   goToPage: (navigate: (path: string) => void, path: string) => void;
 
@@ -71,6 +73,7 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
   isShaking: false,
   preselectedTrack: null,
   isCoverImageFading: false,
+  refreshTrigger: 0,
 
   addSelectedTrackToPlaylistRef: () => {},
 
@@ -95,6 +98,8 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
   setIsShaking: (isShaking) => set({ isShaking }),
   setPreselectedTrack: (preselectedTrack) => set({ preselectedTrack }),
   setIsCoverImageFading: (isCoverImageFading) => set({ isCoverImageFading }),
+  setRefreshTrigger: (value) =>
+    set((state) => ({ refreshTrigger: typeof value === "function" ? value(state.refreshTrigger) : value })),
 
   goToPage: (navigate, path) => navigate(path),
 
@@ -153,9 +158,11 @@ const usePlaylistStore = create<PlaylistStore>((set, get) => ({
       }
 
       const data = await response.json();
-      console.log(data);
       showMessage("newPlaylist");
-      set({ preselectedTrack: null });
+      set((state) => ({
+        preselectedTrack: null,
+        refreshTrigger: state.refreshTrigger + 1,
+      }));
       hideCreatePlaylistModal();
     } catch {
       showMessage("newPlaylistFailed");


### PR DESCRIPTION
## 概要
関連Issue: #132
新規プレイリスト作成後に、画面に反映されないバグを修正

## 変更内容
プレイリストを取得している副作用に依存配列を追加してさらにキャッシュを利用するか最新の値を取得するかの条件分岐に新しい条件を加えた

- プレイリスト取得の`useEffect`に依存配列を追加し、プレイリスト作成時に検知できるよう変更
- キャッシュを利用するかサーバーから最新データを取得するかを判定する条件に、`refreshTrigger`を追加
