### PR TITLE
fix: 曲の追加・削除時にプレイリスト画像が常にfallbackになるバグを修正

### DIFF
--- a/src/components/playlists/PlaylistCoverImageGrid.tsx
+++ b/src/components/playlists/PlaylistCoverImageGrid.tsx
@@ -21,21 +21,23 @@ const PlaylistCoverImageGrid = ({
   const isCoverImageFading = usePlaylistStore((state) => state.isCoverImageFading);
   const showCoverImages = usePlaylistStore((state) => state.showCoverImages);
   const [delayedImages, setDelayedImages] = useState(images);
-  const DELAYED_REFLECTION_TIME = 160;
-  const DELAYED_SHOW_TIME = 600;
+  const COVER_IMAGE_UPDATE_DELAY = 160;
+  const COVER_IMAGE_SHOW_DELAY = 600;
 
+  // 現在開いてるプレイリストに同期させるため ↓
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       setDelayedImages(images);
-    }, DELAYED_REFLECTION_TIME);
+    }, COVER_IMAGE_UPDATE_DELAY);
 
     return () => clearTimeout(timeoutId);
   }, [images]);
 
+  // 曲の追加・削除でカバー画像が一瞬切り替わるちらつきを防ぐため ↓
   useEffect(() => {
     const timer = setTimeout(() => {
       showCoverImages();
-    }, DELAYED_SHOW_TIME);
+    }, COVER_IMAGE_SHOW_DELAY);
 
     return () => clearTimeout(timer);
   }, [isCoverImageFading]);


### PR DESCRIPTION
## 概要
関連Issue: #130
プレイリストで曲を追加・削除時にUI のちらつきを防ぐために一時的にfallback画像に切り替えていたが、常にfallback画像のままになってしまうバグを修正。

## 変更内容
- `PlaylistCoverImageGrid`内にuseEffectを追加して`isCoverImageFading`が発火するタイミング（曲追加 or 削除）時に`setTimeout`で表示するよう変更。

- 定数名を分かりやすい命名に変更